### PR TITLE
fix: upgrade semantic release action to v3

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -41,7 +41,7 @@ runs:
         token: ${{ inputs.token }}
     - name: Release
       id: release
-      uses: cycjimmy/semantic-release-action@v2
+      uses: cycjimmy/semantic-release-action@v3
       with:
         extends: ${{ inputs.release-config }}
       env:


### PR DESCRIPTION
v20 of semantic release is incompatible with node16, and that's what github action uses.

v2 of the action does not version lock semantic-release it uses latest. v3 of the action version locks semantic release to v19.